### PR TITLE
CHALLENGE_DOMAIN should be used when add TXT dns

### DIFF
--- a/cloudflare-update-dns.sh
+++ b/cloudflare-update-dns.sh
@@ -14,7 +14,7 @@ ADD_RECORD_RESULT=$(curl -X POST "https://api.cloudflare.com/client/v4/zones/${C
      -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
      -H "X-Auth-Key: ${CLOUDFLARE_KEY}" \
      -H "Content-Type: application/json" \
-     --data "{\"type\":\"TXT\",\"name\":\"_acme-challenge\",\"content\":\"${CERTBOT_VALIDATION}\", \"ttl\": 120}" -s | jq -r "[.success, .errors[].message] | @csv")
+     --data "{\"type\":\"TXT\",\"name\":\"${CHALLENGE_DOMAIN}\",\"content\":\"${CERTBOT_VALIDATION}\", \"ttl\": 120}" -s | jq -r "[.success, .errors[].message] | @csv")
 
 echo "Add record result: ${ADD_RECORD_RESULT}"
 


### PR DESCRIPTION
用中文没问题吧2333

如果像之前那样 `name: _acme-challenge` ，会为_acme-challenge.example.com创建一个TXT记录，这个方式使用主域名是没问题的，但是如果给二级域名test.example.com申请证书时，要求创建的是_acme-challenge.test.example.com，这样就通过不了了。
因此就改了一下，直接使用CHALLENGE_DOMAIN，试了一下cloudflare是能正常识别出最后的主域名并生成正确的记录的。