### PR TITLE
Allow renewing of subdomains

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -3,8 +3,9 @@ CLOUDFLARE_EMAIL=<input-your-email-here>
 
 CHALLENGE_PREFIX="_acme-challenge"
 CHALLENGE_DOMAIN="${CHALLENGE_PREFIX}.${CERTBOT_DOMAIN}"
+PARENT_DOMAIN=$(sed 's/.*\.\(.*\..*\)/\1/' <<< "${CERTBOT_DOMAIN}")
 
-CLOUDFLARE_ZONE=$(curl -X GET "https://api.cloudflare.com/client/v4/zones?name=${CERTBOT_DOMAIN}" \
+CLOUDFLARE_ZONE=$(curl -X GET "https://api.cloudflare.com/client/v4/zones?name=${PARENT_DOMAIN}" \
      -H "X-Auth-Email: ${CLOUDFLARE_EMAIL}" \
      -H "X-Auth-Key: ${CLOUDFLARE_KEY}" \
      -H "Content-Type: application/json" -s | jq -r '.result[0].id')


### PR DESCRIPTION
The CF API `/zones?name=XXXX` requires the 1st level domain (as shown in the Cloudflare dashboard). This uses a simple sed command to clean the domain from certbot to use the 1st level domain in the request.

Now means you can renew domains like `sub1.example.com`.

Previously, a call to `/v4/zones?name=sub1.example.com` would give 0 results and cause an error in the `cloudflare-update-dns` script. This change makes the call to `/v4/zones?name=example.com` fixing the error.

谢谢提供这些scripts :D